### PR TITLE
Add rolling sum helper func; update constraints; add revenue incentive

### DIFF
--- a/main_model/Main Model.ipynb
+++ b/main_model/Main Model.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b730b0c3",
    "metadata": {},
    "outputs": [],
@@ -10,6 +10,7 @@
     "import calliope\n",
     "import pandas as pd\n",
     "import plotly.express as px\n",
+    "import helper_funcs # load the custom helper function\n",
     "\n",
     "calliope.set_log_verbosity(\"INFO\", include_solver_output=False)"
    ]

--- a/main_model/custom_constraints_delay.yml
+++ b/main_model/custom_constraints_delay.yml
@@ -1,14 +1,18 @@
 constraints:
+  balance_transmission:
+    # Update base constraint to ignore `aluminium_transport_tech`. We'll deal with it in ``.
+    where: base_tech=transmission AND NOT techs=aluminium_transport_tech
+
   aluminium_transport_delay:
-    description: > 
+    description: >
       Enforce a 72-hour delay for aluminium transport from Iceland to Netherlands.
       The amount arriving at NL at time t equals the amount sent from Iceland at time t - 72.
     foreach: [techs, timesteps]
     where: techs=aluminium_transport_tech
     equations:
       - expression: >
-          flow_out[nodes=Netherlands, carriers=aluminium] 
+          flow_out[nodes=Netherlands, carriers=aluminium]
           == default_if_empty(
-               roll(flow_out[nodes=Iceland, carriers=aluminium], timesteps=72), 
+               roll(flow_in[nodes=Iceland, carriers=aluminium], timesteps=72),
                default=0
              )

--- a/main_model/custom_constraints_state.yml
+++ b/main_model/custom_constraints_state.yml
@@ -21,9 +21,30 @@ constraints:
   shipping_capacity_link:
     description: "Allow aluminium flow out of Iceland only when a ship departs (enforce discrete ship usage)"
     foreach: [nodes, techs, timesteps]
-    where: techs=aluminium_transport_tech
+    where: techs=aluminium_transport_tech AND nodes=Iceland
     equations:
-      - expression: flow_out[nodes=Iceland, carriers=aluminium] <= ship_depart * 20000 # Use the max flow of the tech as capacity, 20000 in this case
+      - expression: flow_in[carriers=aluminium] <= ship_depart * flow_cap_max
+
+  ship_limit:
+    description: "There's only one ship so you can only have one departure every 144 hours"
+    foreach: [nodes, techs, timesteps]
+    where: techs=aluminium_transport_tech AND nodes=Iceland
+    equations:
+      - expression: sum_next_n(ship_depart, timesteps, 144) <= 1
+
+  ship_availability_limit:
+    description: "You can only depart if there is availability"
+    foreach: [nodes, techs, timesteps]
+    where: techs=aluminium_transport_tech AND nodes=Iceland
+    equations:
+      - expression: ship_depart <= $prev_available
+    sub_expressions:
+      prev_available:
+        # For t=0, set initial number of ships; for t>0, use previous timestep's availability
+        - where: timesteps = get_val_at_index(timesteps=0) # first timestep
+          expression: "1" # number of ships
+        - where: NOT timesteps = get_val_at_index(timesteps=0)
+          expression: roll(ship_available, timesteps=1) # ship_available at t-1
 
   ship_roundtrip_cycle:
     description: >

--- a/main_model/data_tables/supply_and_demand.csv
+++ b/main_model/data_tables/supply_and_demand.csv
@@ -1,7 +1,7 @@
 comment,"infinite fuel supply","infinite aluminium supply","infinite aluminium demand"
 nodes,Iceland,Iceland,Netherlands
 techs,fuel_supply,aluminium_supply,aluminium_demand
-parameters,source_use_max,source_use_max,sink_use_equals
+parameters,source_use_max,source_use_max,sink_use_max
 timesteps,,,
 2005-01-01 00:00,999999,999999,999999
 2005-01-01 01:00,999999,999999,999999

--- a/main_model/helper_funcs.py
+++ b/main_model/helper_funcs.py
@@ -1,0 +1,42 @@
+import xarray as xr
+from calliope.backend.helper_functions import ParsingHelperFunction
+
+
+class SumNextN(ParsingHelperFunction):
+    """Sum the next N items in an array. Works best for ordered arrays (datetime, integer)."""
+
+    #:
+    NAME = "sum_next_n"
+    #:
+    ALLOWED_IN = ["expression"]
+
+    def as_math_string(self, array: str, *, over: str, N: int) -> str:  # noqa: D102, override
+        overstring = self._instr(over)
+        # FIXME: add N
+        return rf"\sum\limits_{{{overstring}}} ({array})"
+
+    def as_array(self, array: xr.DataArray, over: str, N: int) -> xr.DataArray:
+        """Sum values from current up to N from current on the dimension `over`.
+
+        Args:
+            array (xr.DataArray): Math component array.
+            over (str): Dimension over which to sum
+            N (int): number of items beyond the current value to sum from
+
+        Returns:
+            xr.DataArray:
+                Returns the input array with the condition applied,
+                including having been broadcast across any new dimensions provided by the condition.
+
+        Examples:
+            One common use-case is to collate N timesteps beyond a given timestep to apply a constraint to it(e.g., demand must be less than X in the next 24 hours)
+        """
+        results = []
+        for i in range(len(self._input_data.coords[over])):
+            results.append(
+                array.isel(**{over: slice(i, i + int(N))}).sum(over, min_count=1)
+            )
+        final_array = xr.concat(
+            results, dim=self._input_data.coords[over]
+        ).broadcast_like(array)
+        return final_array

--- a/main_model/model.yaml
+++ b/main_model/model.yaml
@@ -11,7 +11,7 @@ config:
     broadcast_param_data: true
 
   build:
-    ensure_feasibility: true
+    ensure_feasibility: false
     mode: plan
     add_math: [custom_constraints_state.yml, custom_constraints_delay.yml]
 

--- a/main_model/model_config/locations.yaml
+++ b/main_model/model_config/locations.yaml
@@ -18,3 +18,7 @@ nodes:
     techs:
       aluminium_demand:
         carrier: aluminium
+        cost_flow_in:
+          data: -1
+          dims: costs
+          index: monetary

--- a/main_model/model_config/techs.yaml
+++ b/main_model/model_config/techs.yaml
@@ -3,7 +3,6 @@
 ##
 
 techs:
-
   ##
   # Supply
   ##
@@ -39,10 +38,11 @@ techs:
   aluminium_transport_tech:
     link_from: Iceland
     link_to: Netherlands
+    one_way: true
     name: "Aluminium Transport"
     color: "#8465A9"
     base_tech: transmission
     carrier_in: aluminium
     carrier_out: aluminium
     flow_cap_max: 20000 # Maximum capacity for aluminium transmission
-    flow_out_eff: 1  # Transmission efficiency
+    flow_out_eff: 1 # Transmission efficiency


### PR DESCRIPTION
A bunch of fixes to get things (mostly) working.

The new helper function is automatically recognised by Calliope because it is a subclass of the calliope helper function base class and is imported in the jupyter notebook. `sum_next_n` is then available in the math.

It seems there's still the edge case where departing in the final day or so still leaves "ship_available" as 1. I assume this is because the rolling sum has fewer entries in the final three days?

I added a negative cost for Al demand so the optimisation is incentivised to actually meet it and didn't _force_ the demand to be met in every timestep (it can't be since the ship can only arrive once every 6 days!).